### PR TITLE
Disable clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,3 @@ path = "test/test.rs"
 [dependencies]
 libc = "0.1.8"
 tempdir = "0.3.4"
-clippy = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 #![feature(plugin)]
-#![plugin(clippy)]
 
 extern crate libc;
 


### PR DESCRIPTION
Clippy can't build with nightly rust.
