### PR TITLE
save path for later use

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -30,6 +30,7 @@ const DEFAULT_COLUMN_FAMILY: &'static str = "default";
 pub struct DB {
     inner: rocksdb_ffi::DBInstance,
     cfs: BTreeMap<String, DBCFHandle>,
+    path: String,
 }
 
 unsafe impl Send for DB {}
@@ -373,6 +374,7 @@ impl DB {
         Ok(DB {
             inner: db,
             cfs: cf_map,
+            path: path.to_owned(),
         })
     }
 
@@ -408,6 +410,10 @@ impl DB {
             return Err(error_message(err));
         }
         Ok(())
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 
     pub fn write_opt(&self,


### PR DESCRIPTION
We will get the total rocksdb used size and report to pd regularly. 

So it is convenient that keeping path in DB so that we can get it easily. 

@ngaut @BusyJay 