### PR TITLE
add set_iterate_upper_bound api for readoptions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use rocksdb::{BlockBasedOptions, DB, DBCompressionType, Options};
+    use rocksdb::{BlockBasedOptions, DB, DBCompressionType, Options, ReadOptions, WriteOptions, SeekKey};
     use rocksdb::DBCompactionStyle::DBUniversal;
 
     #[allow(dead_code)]
@@ -190,6 +190,33 @@ mod tests {
         // opts.set_filter(filter);
 
         DB::open(&opts, path).unwrap()
+    }
+
+    #[test]
+    fn read_with_upper_bound() {
+        let path = "_rust_rocksdb_read_with_upper_bound_test";
+        let mut opts = Options::new();
+        opts.create_if_missing(true);
+        {
+            let db = DB::open(&opts, path).unwrap();
+            let writeopts = WriteOptions::new();
+            db.put_opt(b"k1-0", b"a", &writeopts).unwrap();
+            db.put_opt(b"k1-1", b"b", &writeopts).unwrap();
+            db.put_opt(b"k2-0", b"c", &writeopts).unwrap();
+
+            let mut readopts = ReadOptions::new();
+            readopts.set_iterate_upper_bound("k2");
+            let mut iter = db.iter_opt(readopts);
+            iter.seek(SeekKey::Start);
+            let mut count = 0;
+            while iter.valid() {
+                count += 1;
+                if !iter.next() {
+                    break;
+                }
+            }
+            assert_eq!(count, 2);
+        }
     }
 
     // TODO(tyler) unstable

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ mod tests {
             db.put_opt(b"k2-0", b"c", &writeopts).unwrap();
 
             let mut readopts = ReadOptions::new();
-            readopts.set_iterate_upper_bound("k2");
+            readopts.set_iterate_upper_bound(b"k2");
             let mut iter = db.iter_opt(readopts);
             iter.seek(SeekKey::Start);
             let mut count = 0;

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -42,7 +42,7 @@ pub struct WriteBatch {
 
 pub struct ReadOptions {
     inner: rocksdb_ffi::DBReadOptions,
-    upper_bound: String,
+    upper_bound: Vec<u8>,
 }
 
 /// The UnsafeSnap must be destroyed by db, it maybe be leaked
@@ -1062,7 +1062,7 @@ impl Drop for ReadOptions {
 impl Default for ReadOptions {
     fn default() -> ReadOptions {
         unsafe {
-            ReadOptions { inner: rocksdb_ffi::rocksdb_readoptions_create(), upper_bound: String::new() }
+            ReadOptions { inner: rocksdb_ffi::rocksdb_readoptions_create(), upper_bound: vec![] }
         }
     }
 }
@@ -1086,8 +1086,8 @@ impl ReadOptions {
                                                       snapshot.inner);
     }
 
-    pub fn set_iterate_upper_bound(&mut self, key: &str) {
-        self.upper_bound = String::from(key);
+    pub fn set_iterate_upper_bound(&mut self, key: &[u8]) {
+        self.upper_bound = Vec::from(key);
         unsafe {
             rocksdb_ffi::rocksdb_readoptions_set_iterate_upper_bound(self.inner,
                                                                      self.upper_bound.as_ptr(),

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -42,6 +42,7 @@ pub struct WriteBatch {
 
 pub struct ReadOptions {
     inner: rocksdb_ffi::DBReadOptions,
+    upper_bound: String,
 }
 
 /// The UnsafeSnap must be destroyed by db, it maybe be leaked
@@ -62,6 +63,7 @@ pub struct Snapshot<'a> {
 #[allow(dead_code)]
 pub struct DBIterator<'a> {
     db: &'a DB,
+    readopts: ReadOptions,
     inner: rocksdb_ffi::DBIterator,
 }
 
@@ -78,13 +80,14 @@ impl<'a> From<&'a [u8]> for SeekKey<'a> {
 }
 
 impl<'a> DBIterator<'a> {
-    pub fn new(db: &'a DB, readopts: &ReadOptions) -> DBIterator<'a> {
+    pub fn new(db: &'a DB, readopts: ReadOptions) -> DBIterator<'a> {
         unsafe {
             let iterator = rocksdb_ffi::rocksdb_create_iterator(db.inner,
                                                                 readopts.inner);
 
             DBIterator {
                 db: db,
+                readopts: readopts,
                 inner: iterator,
             }
         }
@@ -159,7 +162,7 @@ impl<'a> DBIterator<'a> {
 
     pub fn new_cf(db: &'a DB,
                   cf_handle: DBCFHandle,
-                  readopts: &ReadOptions)
+                  readopts: ReadOptions)
                   -> DBIterator<'a> {
         unsafe {
             let iterator =
@@ -168,6 +171,7 @@ impl<'a> DBIterator<'a> {
                                                         cf_handle);
             DBIterator {
                 db: db,
+                readopts: readopts,
                 inner: iterator,
             }
         }
@@ -215,7 +219,7 @@ impl<'a> Snapshot<'a> {
         unsafe {
             opt.set_snapshot(&self.snap);
         }
-        DBIterator::new(self.db, &opt)
+        DBIterator::new(self.db, opt)
     }
 
     pub fn get(&self, key: &[u8]) -> Result<Option<DBVector>, String> {
@@ -590,16 +594,16 @@ impl DB {
 
     pub fn iter(&self) -> DBIterator {
         let opts = ReadOptions::new();
-        self.iter_opt(&opts)
+        self.iter_opt(opts)
     }
 
-    pub fn iter_opt(&self, opt: &ReadOptions) -> DBIterator {
+    pub fn iter_opt(&self, opt: ReadOptions) -> DBIterator {
         DBIterator::new(&self, opt)
     }
 
     pub fn iter_cf(&self, cf_handle: DBCFHandle) -> DBIterator {
         let opts = ReadOptions::new();
-        DBIterator::new_cf(&self, cf_handle, &opts)
+        DBIterator::new_cf(&self, cf_handle, opts)
     }
 
     pub fn snapshot(&self) -> Snapshot {
@@ -1058,7 +1062,7 @@ impl Drop for ReadOptions {
 impl Default for ReadOptions {
     fn default() -> ReadOptions {
         unsafe {
-            ReadOptions { inner: rocksdb_ffi::rocksdb_readoptions_create() }
+            ReadOptions { inner: rocksdb_ffi::rocksdb_readoptions_create(), upper_bound: String::new() }
         }
     }
 }
@@ -1082,11 +1086,12 @@ impl ReadOptions {
                                                       snapshot.inner);
     }
 
-    pub fn set_iterate_upper_bound(&mut self, key: &[u8]) {
+    pub fn set_iterate_upper_bound(&mut self, key: &str) {
+        self.upper_bound = String::from(key);
         unsafe {
             rocksdb_ffi::rocksdb_readoptions_set_iterate_upper_bound(self.inner,
-                                                                     key.as_ptr(),
-                                                                     key.len() as size_t);
+                                                                     self.upper_bound.as_ptr(),
+                                                                     self.upper_bound.len() as size_t);
         }
     }
 }

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -1081,6 +1081,14 @@ impl ReadOptions {
         rocksdb_ffi::rocksdb_readoptions_set_snapshot(self.inner,
                                                       snapshot.inner);
     }
+
+    pub fn set_iterate_upper_bound(&mut self, key: &[u8]) {
+        unsafe {
+            rocksdb_ffi::rocksdb_readoptions_set_iterate_upper_bound(self.inner,
+                                                                     key.as_ptr(),
+                                                                     key.len() as size_t);
+        }
+    }
 }
 
 pub struct DBVector {


### PR DESCRIPTION
"iterate_upper_bound" defines the extent up to which the forward iterator can returns entries. Once the bound is reached, Valid() will be false. 