### PR TITLE
hold `Options` instance in `DB` instance

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn custom_merge() {
     opts.create_if_missing(true);
     opts.add_merge_operator("test operator", concat_merge);
     {
-        let db = DB::open(&opts, path).unwrap();
+        let db = DB::open(opts, path).unwrap();
         db.put(b"k1", b"a").unwrap();
         db.merge(b"k1", b"b").unwrap();
         db.merge(b"k1", b"c").unwrap();
@@ -108,6 +108,7 @@ fn custom_merge() {
             Err(e) => println!("error retrieving value: {}", e),
         }
     }
+    let opts = Options::new();
     DB::destroy(&opts, path).is_ok();
 }
 
@@ -146,7 +147,7 @@ mod tests {
 
     #[allow(dead_code)]
     fn tuned_for_somebody_elses_disk(path: &str,
-                                     opts: &mut Options,
+                                     mut opts: Options,
                                      blockopts: &mut BlockBasedOptions)
                                      -> DB {
         let per_level_compression: [DBCompressionType; 7] = [DBCompressionType::DBNo,
@@ -189,7 +190,7 @@ mod tests {
         // let filter = new_bloom_filter(10);
         // opts.set_filter(filter);
 
-        DB::open(&opts, path).unwrap()
+        DB::open(opts, path).unwrap()
     }
 
     // TODO(tyler) unstable

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -180,7 +180,7 @@ mod test {
         let mut opts = Options::new();
         opts.create_if_missing(true);
         opts.add_merge_operator("test operator", test_provided_merge);
-        let db = DB::open(&opts, path.path().to_str().unwrap()).unwrap();
+        let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
         let p = db.put(b"k1", b"a");
         assert!(p.is_ok());
         let _ = db.merge(b"k1", b"b");

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -316,7 +316,7 @@ impl DB {
 
             // These handles will be populated by DB.
             let cfhandles: Vec<_> = cfs_v.iter()
-                .map(|_| 0 as *mut DBCFHandle)
+                .map(|_| ptr::null_mut() as *mut DBCFHandle)
                 .collect();
 
             let cfopts: Vec<_> = cf_opts_v.iter()

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -316,7 +316,7 @@ impl DB {
 
             // These handles will be populated by DB.
             let cfhandles: Vec<_> = cfs_v.iter()
-                .map(|_| ptr::null_mut() as *mut DBCFHandle)
+                .map(|_| ptr::null_mut())
                 .collect();
 
             let cfopts: Vec<_> = cf_opts_v.iter()

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -566,12 +566,6 @@ impl Drop for FlushOptions {
             rocksdb_ffi::rocksdb_flushoptions_destroy(self.inner);
         }
     }
-
-    pub fn set_num_levels(&mut self, n: c_int) {
-        unsafe {
-            rocksdb_ffi::rocksdb_options_set_num_levels(self.inner, n);
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -550,6 +550,12 @@ impl Drop for FlushOptions {
             rocksdb_ffi::rocksdb_flushoptions_destroy(self.inner);
         }
     }
+
+    pub fn set_num_levels(&mut self, n: c_int) {
+        unsafe {
+            rocksdb_ffi::rocksdb_options_set_num_levels(self.inner, n);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/test/test_column_family.rs
+++ b/test/test_column_family.rs
@@ -26,7 +26,7 @@ pub fn test_column_family() {
         let mut opts = Options::new();
         opts.create_if_missing(true);
         opts.add_merge_operator("test operator", test_provided_merge);
-        let mut db = DB::open(&opts, path_str).unwrap();
+        let mut db = DB::open(opts, path_str).unwrap();
         let opts = Options::new();
         match db.create_cf("cf1", &opts) {
             Ok(_) => println!("cf1 created successfully"),
@@ -41,7 +41,7 @@ pub fn test_column_family() {
     {
         let mut opts = Options::new();
         opts.add_merge_operator("test operator", test_provided_merge);
-        match DB::open(&opts, path_str) {
+        match DB::open(opts, path_str) {
             Ok(_) => {
                 panic!("should not have opened DB successfully without \
                         specifying column
@@ -58,7 +58,7 @@ pub fn test_column_family() {
     {
         let mut opts = Options::new();
         opts.add_merge_operator("test operator", test_provided_merge);
-        match DB::open_cf(&opts, path_str, &["cf1"], &[&opts]) {
+        match DB::open_cf(Options::new(), path_str, &["cf1"], &[&opts]) {
             Ok(_) => println!("successfully opened db with column family"),
             Err(e) => panic!("failed to open db with column family: {}", e),
         }
@@ -67,7 +67,7 @@ pub fn test_column_family() {
     {
         let mut opts = Options::new();
         opts.add_merge_operator("test operator", test_provided_merge);
-        let db = match DB::open_cf(&opts, path_str, &["cf1"], &[&opts]) {
+        let db = match DB::open_cf(Options::new(), path_str, &["cf1"], &[&opts]) {
             Ok(db) => {
                 println!("successfully opened db with column family");
                 db
@@ -115,7 +115,7 @@ pub fn test_column_family() {
     }
     // should b able to drop a cf
     {
-        let mut db = DB::open_cf(&Options::new(), path_str, &["cf1"], &[&Options::new()]).unwrap();
+        let mut db = DB::open_cf(Options::new(), path_str, &["cf1"], &[&Options::new()]).unwrap();
         match db.drop_cf("cf1") {
             Ok(_) => println!("cf1 successfully dropped."),
             Err(e) => panic!("failed to drop column family: {}", e),

--- a/test/test_compact_range.rs
+++ b/test/test_compact_range.rs
@@ -7,7 +7,7 @@ fn test_compact_range() {
     let path = TempDir::new("_rust_rocksdb_test_compact_range").expect("");
     let mut opts = Options::new();
     opts.create_if_missing(true);
-    let db = DB::open(&opts, path.path().to_str().unwrap()).unwrap();
+    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
     let samples = vec![
         (b"k1".to_vec(), b"value--------1".to_vec()),
         (b"k2".to_vec(), b"value--------2".to_vec()),

--- a/test/test_compaction_filter.rs
+++ b/test/test_compaction_filter.rs
@@ -37,7 +37,7 @@ fn test_compaction_filter() {
                                }))
         .unwrap();
     opts.create_if_missing(true);
-    let db = DB::open(&opts, path.path().to_str().unwrap()).unwrap();
+    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
     let samples = vec![
         (b"key1".to_vec(), b"value1".to_vec()),
         (b"key2".to_vec(), b"value2".to_vec()),
@@ -58,7 +58,9 @@ fn test_compaction_filter() {
     }
     drop(db);
 
+
     // reregister with ignore_snapshots set to true
+    let mut opts = Options::new();
     opts.set_compaction_filter("test",
                                true,
                                Box::new(Filter {
@@ -69,7 +71,7 @@ fn test_compaction_filter() {
     assert!(drop_called.load(Ordering::Relaxed));
     drop_called.store(false, Ordering::Relaxed);
     {
-        let db = DB::open(&opts, path.path().to_str().unwrap()).unwrap();
+        let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
         let _snap = db.snapshot();
         // Because ignore_snapshots is true, so all the keys will be compacted.
         db.compact_range(Some(b"key1"), Some(b"key3"));
@@ -79,6 +81,5 @@ fn test_compaction_filter() {
         assert_eq!(*filtered_kvs.read().unwrap(), samples);
     }
 
-    drop(opts);
     assert!(drop_called.load(Ordering::Relaxed));
 }

--- a/test/test_iterator.rs
+++ b/test/test_iterator.rs
@@ -118,7 +118,7 @@ fn read_with_upper_bound() {
     let mut opts = Options::new();
     opts.create_if_missing(true);
     {
-        let db = DB::open(&opts, path.path().to_str().unwrap()).unwrap();
+        let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
         let writeopts = WriteOptions::new();
         db.put_opt(b"k1-0", b"a", &writeopts).unwrap();
         db.put_opt(b"k1-1", b"b", &writeopts).unwrap();

--- a/test/test_rocksdb_options.rs
+++ b/test/test_rocksdb_options.rs
@@ -8,6 +8,6 @@ fn test_set_num_levels() {
     let mut opts = Options::new();
     opts.create_if_missing(true);
     opts.set_num_levels(2);
-    let db = DB::open(&opts, path.path().to_str().unwrap()).unwrap();
+    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
     drop(db);
 }


### PR DESCRIPTION
Hold `Options` instance in `DB` instance, so we can call function `get_statistics` of `Options` from `DB` instance.
@siddontang @BusyJay PTAL